### PR TITLE
lock table text font size to 14px

### DIFF
--- a/components/open_data_theme.css
+++ b/components/open_data_theme.css
@@ -282,6 +282,12 @@
     U+FEFF, U+FFFD;
 }
 
+/* To ensure Data Catalog Table panels had consistent text sizing */
+
+.odswidget-table__cell-container span {
+  font-size: 14px;
+}
+
 /* Make API link in Catalog page same font-size */
 
 a.ods-catalog-card__visualization.ng-scope > span {


### PR DESCRIPTION
Fixes a visual bug where geopoints would be made font-size: 16px by the class .ng-scope.
