### PR TITLE
add caveat about geospatial data

### DIFF
--- a/accessory_pages/help.html
+++ b/accessory_pages/help.html
@@ -36,8 +36,10 @@
       options for download.
       <br />
       <br />
-      If you are looking for further geospatial data such as raster, vector, or
-      drone imagery Cary provides these data via the
+      Please note that <strong>all</strong> imported geospatial data is
+      reprojected from Coordinate Reference System NAD83 / North Carolina (ftUS)
+      EPSG:2264, to WGS84. If you are looking for more geospatial data such as
+      raster, vector, or drone imagery Cary provides these data via the
       <a href="https://maps.townofcary.org/arcgis1/rest/services"
         >ArcGIS REST Services Directory</a
       >. Which these data can be imported into geospatial analysis software such


### PR DESCRIPTION
- Adds caveat to Help page on the reprojection of imported data.
- Further investigation needs to be conducted on the caveats to precision.
- WGS84 has a temporal component:
    - When data is collected affects the precision.
